### PR TITLE
add token parameter to action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
   gh_token:
     description: "GitHub Token to be used to access the repo"
     required: true
-    default: ${{ secrets.GITHUB_TOKEN }}
+    default: ${{ github.token }}
 outputs:
   resultJson:
     description: "Table of updates in Json format"
@@ -69,7 +69,7 @@ runs:
       shell: pwsh
       env:
         Role: ${{inputs.role}}
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ inputs.gh_token }}
         what_if_mode: ${{inputs.what_if_mode}}
       run: |
           # Run Sync-RepoAccess

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: "When true no change will happen in the repo. You will get analysis output"
     required: true
     default: 'true'
+  gh_token:
+    description: "GitHub Token to be used to access the repo"
+    required: true
+    default: ${{ secrets.GITHUB_TOKEN }}
 outputs:
   resultJson:
     description: "Table of updates in Json format"


### PR DESCRIPTION
Allow to add a specific token to be used when accessing the repo.

You can use this input to specify PAT or to feed a tocken generated with a GitHub App.

https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/making-authenticated-api-requests-with-a-github-app-in-a-github-actions-workflow

By default it will use secrets.GITHUB_TOKEN